### PR TITLE
Bbob 374 fixing tag name for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ github.ref_name }}
+          tag_name: ${{ github.sha }}
           release_name: ${{ github.ref_name }}
           draft: false
           prerelease: false


### PR DESCRIPTION
Previously was using `${{ github.ref }}` which corresponds to the branch name, which is always going to be `main`

Changed to `$ {{ github.sha }}` which is "The commit SHA that triggered the workflow." and should thus be unique each run.