### PR TITLE
BBOB-374 - Final upload fixes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.PAT }}
         with:
+#         Annoyingly, there's no helpful value to set these to that I can, and no auto-increment stuff in GHA without
+#         using a third party Action and even then it's a pain
           tag_name: ${{ github.run_number }}
           release_name: ${{ github.run_number }}
           draft: false

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -33,3 +33,4 @@ jobs:
         run: |
           docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          aws ecs update-service --force-new-deployment --service ecs_webserver --cluster ecs_webserver


### PR DESCRIPTION
Added a comment about Release names.

Also, trying to update the ECS service using AWS CLI. This should cause ECS to deploy using the new `latest` post-upload.